### PR TITLE
Fix test_webhook check on discord prefix to work on ubuntu

### DIFF
--- a/load.py
+++ b/load.py
@@ -501,7 +501,9 @@ def test_webhook() -> None:
     webhook_url = config_state.webhook_entry.get().strip() if config_state.webhook_entry else ""
     image_url = config_state.image_entry.get().strip() if config_state.image_entry else ""
     
-    if not webhook_url.startswith("https://discord.com/api/webhooks/"):
+    if not webhook_url.startswith(
+        ("https://discord.com/api/webhooks/", "https://discordapp.com/api/webhooks/")
+    ):
         logger.warning("Invalid webhook URL format")
         return
     


### PR DESCRIPTION
Discord on Ubuntu uses https://discordapp.com instead of https://discord.com. Adding this prefix to the webhook_url check for cross platform compatibiilty